### PR TITLE
Add grouped Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      pip-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      pip-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      actions-version:
+        applies-to: version-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds `.github/dependabot.yml` with grouped Dependabot updates — a security-updates group and a version-updates group per ecosystem (`*` patterns) — so Dependabot opens one grouped PR per ecosystem instead of one PR per advisory.

Ecosystems: pip, github-actions.

Mirrors the config added to plausible-cf-worker.